### PR TITLE
constraint window to not go smaller

### DIFF
--- a/src/gtk/window.ui
+++ b/src/gtk/window.ui
@@ -2,6 +2,7 @@
 <interface>
   <requires lib="gtk" version="4.0"/>
   <template class="VanillaWindow" parent="AdwApplicationWindow">
+    <property name="width-request">400</property>
     <property name="default-width">990</property>
     <property name="default-height">700</property>
     <property name="title" translatable="yes">Vanilla OS Control Center</property>


### PR DESCRIPTION
hi,

added `width-request` with `400` as value so that when `vanilla-control-center` is resized horizontally,it wont reduce less than this.
currently without this the window can go smaller than this. 