### PR TITLE
Corrected name of "About" section of the window

### DIFF
--- a/src/gtk/window.ui
+++ b/src/gtk/window.ui
@@ -158,7 +158,7 @@
   <menu id="primary_menu">
     <section>
       <item>
-        <attribute name="label" translatable="true">_About Control-panel</attribute>
+        <attribute name="label" translatable="true">_About Control-center</attribute>
         <attribute name="action">app.about</attribute>
       </item>
     </section>


### PR DESCRIPTION
I think we also need to correct all msgid's related to "About" section in .po files