### PR TITLE
po: Fix typo in Source string

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-11-14 21:46+0000\n"
 "Last-Translator: عثمان محامدي <othmahammedi@proton.me>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/vanilla-os/"
@@ -119,7 +119,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-10-22 21:54+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -115,7 +115,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-10-22 21:54+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -114,7 +114,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-11-11 08:49+0000\n"
 "Last-Translator: Olawenah <adriabrucortes@gmail.com>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/vanilla-os/"
@@ -117,7 +117,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/ckb.po
+++ b/po/ckb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-10-22 21:54+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -114,7 +114,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-12-22 11:48+0000\n"
 "Last-Translator: Michal Maděra <misamadera1@gmail.com>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/vanilla-os/control-"
@@ -120,7 +120,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/da.po
+++ b/po/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-10-22 21:54+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -115,7 +115,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-12-10 23:53+0000\n"
 "Last-Translator: Chris <wolrekids@gmail.com>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/vanilla-os/"
@@ -119,7 +119,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-12-16 13:48+0000\n"
 "Last-Translator: stathious <stathious@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/vanilla-os/control-"
@@ -120,7 +120,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-11-30 03:48+0000\n"
 "Last-Translator: phlostically <phlostically@mailinator.com>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/vanilla-os/"
@@ -118,7 +118,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-11-09 04:10+0000\n"
 "Last-Translator: Jehu Marcos Herrera Puentes <jehuherrerap@hotmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/vanilla-os/"
@@ -120,7 +120,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/et.po
+++ b/po/et.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-10-22 21:54+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -115,7 +115,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/eu.po
+++ b/po/eu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-10-22 21:54+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -114,7 +114,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-10-22 21:54+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -114,7 +114,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-10-22 21:54+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -115,7 +115,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-11-06 00:07+0000\n"
 "Last-Translator: Raphaël Denni <raphoro.d@gmail.com>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/vanilla-os/"
@@ -120,7 +120,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/gl.po
+++ b/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-12-10 23:53+0000\n"
 "Last-Translator: Martin Meizoso <martinmeizoso@gmail.com>\n"
 "Language-Team: Galician <https://hosted.weblate.org/projects/vanilla-os/"
@@ -119,7 +119,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-12-13 10:48+0000\n"
 "Last-Translator: Neeraj55#5 <thakurfazer55@gmail.com>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/vanilla-os/control-"
@@ -117,7 +117,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-10-22 21:54+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -116,7 +116,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -116,7 +116,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-11-09 04:10+0000\n"
 "Last-Translator: Ophellia <nekopoihentai69@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/vanilla-os/"
@@ -120,7 +120,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-11-05 21:12+0000\n"
 "Last-Translator: Mirko Brombin <send@mirko.pm>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/vanilla-os/"
@@ -120,7 +120,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-12-04 04:48+0000\n"
 "Last-Translator: Ryo Nakano <ryonakaknock3@gmail.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/vanilla-os/"
@@ -117,7 +117,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-11-09 04:10+0000\n"
 "Last-Translator: 이정희 <daemul72@gmail.com>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/vanilla-os/"
@@ -118,7 +118,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-10-22 21:54+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -116,7 +116,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/ms.po
+++ b/po/ms.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -118,7 +118,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-10-22 21:54+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -115,7 +115,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -118,7 +118,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -117,7 +117,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-11-21 19:59+0000\n"
 "Last-Translator: Rodrigo Pedro <rodrigoresendespedro@gmail.com>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/vanilla-os/"
@@ -122,7 +122,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-11-27 08:47+0000\n"
 "Last-Translator: Ryuna Uemura Cortez <lunascarlatto@outlook.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -120,7 +120,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/ro.po
+++ b/po/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-11-19 20:47+0000\n"
 "Last-Translator: finnmonstar <finnmonstar@pm.me>\n"
 "Language-Team: Romanian <https://hosted.weblate.org/projects/vanilla-os/"
@@ -121,7 +121,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-11-09 04:10+0000\n"
 "Last-Translator: sherichev <s9erx2@yandex.ru>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/vanilla-os/"
@@ -121,7 +121,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-11-05 21:07+0000\n"
 "Last-Translator: Viktor <viktor@grigel.one>\n"
 "Language-Team: Slovak <https://hosted.weblate.org/projects/vanilla-os/"
@@ -120,7 +120,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-10-22 21:54+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -116,7 +116,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-10-22 21:54+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -116,7 +116,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -116,7 +116,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/ta.po
+++ b/po/ta.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -116,7 +116,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -116,7 +116,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-11-25 00:46+0000\n"
 "Last-Translator: Veysel Erden <veyselerden@outlook.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/vanilla-os/"
@@ -118,7 +118,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-11-09 04:10+0000\n"
 "Last-Translator: Serhii Chebanenko <4e6anenk0@gmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/vanilla-os/"
@@ -120,7 +120,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/vanilla-control-center.pot
+++ b/po/vanilla-control-center.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -115,7 +115,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-11-09 04:10+0000\n"
 "Last-Translator: Nguyễn Phú Trọng <minhhoang9105@gmail.com>\n"
 "Language-Team: Vietnamese <https://hosted.weblate.org/projects/vanilla-os/"
@@ -119,7 +119,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-11-09 04:10+0000\n"
 "Last-Translator: Nguyễn Phú Trọng <minhhoang9105@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -117,7 +117,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vanilla-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:34+0530\n"
+"POT-Creation-Date: 2022-12-25 18:54+0530\n"
 "PO-Revision-Date: 2022-10-22 21:54+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -114,7 +114,7 @@ msgstr ""
 
 #: src/gtk/window.ui:110
 msgid ""
-"If enabled, the system will not update if the system is in high load or "
+"If enabled, the system will not update if the system is in high load or the "
 "battery is low."
 msgstr ""
 

--- a/src/gtk/window.ui
+++ b/src/gtk/window.ui
@@ -107,7 +107,7 @@
                             <child>
                               <object class="AdwActionRow" id="row_update_smart">
                                 <property name="title" translatable="true">SmartUpdate</property>
-                                <property name="subtitle" translatable="true">If enabled, the system will not update if the system is in high load or battery is low.</property>
+                                <property name="subtitle" translatable="true">If enabled, the system will not update if the system is in high load or the battery is low.</property>
                                 <child type="suffix">
                                   <object class="GtkSwitch" id="switch_update_smart">
                                     <property name="valign">center</property>


### PR DESCRIPTION
Signed-off-by: K.B.Dharun Krishna <kbdharunkrishna@gmail.com>

## Changes

- Added a missing article to the source string and regenerated po files automatically using the below commands:-
  - `meson /tmp/translation-build`
  - `meson compile -C /tmp/translation-build vanilla-control-center-pot`
  - `meson compile -C /tmp/translation-build vanilla-control-center-update-po`