### PR TITLE
Remove 'ubuntu-drivers-common' dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,9 +13,9 @@ Build-Depends:
             make,
             desktop-file-utils,
             libjpeg-dev
-Homepage: https://github.com/mirkobrombin/vanilla-control-center/
-Vcs-Browser: https://github.com/mirkobrombin/vanilla-control-center
-Vcs-Git: https://github.com/mirkobrombin/vanilla-control-center.git
+Homepage: https://github.com/Vanilla-OS/vanilla-control-center/
+Vcs-Browser: https://github.com/Vanilla-OS/vanilla-control-center
+Vcs-Git: https://github.com/Vanilla-OS/vanilla-control-center.git
 Rules-Requires-Root: no
 
 Package: vanilla-control-center

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: vanilla-control-center
 Section: utils
 Priority: optional
 Maintainer: Mirko Brombin <send@mirko.pm>
-Build-Depends: 
+Build-Depends:
             itstool,
             build-essential,
             debhelper,
@@ -14,7 +14,7 @@ Build-Depends:
             desktop-file-utils,
             libjpeg-dev
 Homepage: https://github.com/mirkobrombin/vanilla-control-center/
-Vcs-Browser: hhttps://github.com/mirkobrombin/vanilla-control-center
+Vcs-Browser: https://github.com/mirkobrombin/vanilla-control-center
 Vcs-Git: https://github.com/mirkobrombin/vanilla-control-center.git
 Rules-Requires-Root: no
 
@@ -25,7 +25,6 @@ Depends: python3,
          libadwaita-1-0,
          gir1.2-gtk-4.0,
          gir1.2-adw-1,
-         ubuntu-drivers-common,
          apx,
          vanilla-system-operator
 Description: This utility allows you to manage Vanilla OS components.


### PR DESCRIPTION
Shouldn't be necessary now that VCC doesn't handle drivers anymore.