### PR TITLE
Add Vte version requirement

### DIFF
--- a/vanilla_control_center/main.py
+++ b/vanilla_control_center/main.py
@@ -27,6 +27,7 @@ import locale
 
 gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
+gi.require_version('Vte', '3.91')
 
 from gi.repository import Gtk, Gio, Adw
 from .window import VanillaWindow


### PR DESCRIPTION
Adds a vte version requirement in the `main.py` to fix some startup warnings.

Should fix #156 