### PR TITLE
added vte4 as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - libadwaita-1-dev
 - gettext
 - desktop-file-utils
+- vte4
 
 ### Build
 ```bash


### PR DESCRIPTION
The add of `vte4` as dependency to be installed fixes the following error:
```
Traceback (most recent call last):
  File "/usr/local/bin/vanilla-control-center", line 45, in <module>
    from vanilla_control_center import main
  File "/usr/local/share/vanilla-control-center/vanilla_control_center/main.py", line 29, in <module>
    gi.require_version('Vte', '3.91')
  File "/usr/lib/python3.11/site-packages/gi/__init__.py", line 129, in require_version
    raise ValueError('Namespace %s not available for version %s' %
ValueError: Namespace Vte not available for version 3.91
```