### PR TITLE
Fixed right distrobox path

### DIFF
--- a/vanilla_control_center/backends/apx.py
+++ b/vanilla_control_center/backends/apx.py
@@ -71,12 +71,12 @@ class Apx:
             return False
 
         if self.__binary is None:
-            print(self.__dbox_binary)
             logger.info(_("Apx binary not found!!!!!"))
             return False
 
         if not os.path.exists(self.__dbox_binary):
-            logger.info(_("Distrobox binary not found"))
+            print(self.__dbox_binary)
+            logger.info(_("Distrobox binary not found!!!!!"))
             return False
 
         return True

--- a/vanilla_control_center/backends/apx.py
+++ b/vanilla_control_center/backends/apx.py
@@ -71,7 +71,8 @@ class Apx:
             return False
 
         if self.__binary is None:
-            logger.info(_("Apx binary not found"))
+            print(self.__dbox_binary)
+            logger.info(_("Apx binary not found!!!!!"))
             return False
 
         if not os.path.exists(self.__dbox_binary):

--- a/vanilla_control_center/backends/apx.py
+++ b/vanilla_control_center/backends/apx.py
@@ -60,7 +60,7 @@ class Apx:
 
     def __init__(self):
         self.__binary = shutil.which("apx")
-        self.__dbox_binary = "/usr/share/apx/bin/distrobox"
+        self.__dbox_binary = "/usr/share/apx/distrobox"
         self.__desktop = os.path.join(Path.home(), ".local", "share", "applications")
         self.__apps = self.__get_apps()
     

--- a/vanilla_control_center/backends/apx.py
+++ b/vanilla_control_center/backends/apx.py
@@ -60,7 +60,7 @@ class Apx:
 
     def __init__(self):
         self.__binary = shutil.which("apx")
-        self.__dbox_binary = "/usr/lib/apx/distrobox"
+        self.__dbox_binary = "/usr/share/apx/bin/distrobox"
         self.__desktop = os.path.join(Path.home(), ".local", "share", "applications")
         self.__apps = self.__get_apps()
     

--- a/vanilla_control_center/backends/apx.py
+++ b/vanilla_control_center/backends/apx.py
@@ -71,12 +71,11 @@ class Apx:
             return False
 
         if self.__binary is None:
-            logger.info(_("Apx binary not found!!!!!"))
+            logger.info(_("Apx binary not found"))
             return False
 
         if not os.path.exists(self.__dbox_binary):
-            print(self.__dbox_binary)
-            logger.info(_("Distrobox binary not found!!!!!"))
+            logger.info(_("Distrobox binary not found"))
             return False
 
         return True


### PR DESCRIPTION
__dbox_binary was pointing to an old and non-existing path `/usr/lib/apx/distrobox` because on new version of vanilla control center and apx, the distrobox binaries are generated and stored in `/usr/share/apx/` folder. It fixes the issue https://github.com/Vanilla-OS/vanilla-control-center/issues/164

PS: Not clear why the installation of apx creates an empty `bin` folder in `/usr/share/apx` and the distrobox binaries are put on `/usr/share/apx` instead of `bin` folder. If they should go in `bin` folder, then, the change on the folder changed in this PR must be edited to `/usr/share/apx/bin`.